### PR TITLE
Fixing filenames that can not be converted to ByteString

### DIFF
--- a/lib/assets/javascripts/jack_up/file_uploader.coffee
+++ b/lib/assets/javascripts/jack_up/file_uploader.coffee
@@ -40,7 +40,7 @@ class @JackUp.FileUploader
     xhr.open 'POST', @path, true
 
     xhr.setRequestHeader 'Content-Type', file.type
-    xhr.setRequestHeader 'X-File-Name', unescape(encodeURIComponent(file.name)
+    xhr.setRequestHeader 'X-File-Name', unescape(encodeURIComponent(file.name))
     xhr.setRequestHeader 'X-CSRF-Token', $('meta[name=csrf-token]').attr('content')
 
     @trigger 'upload:start', file: file

--- a/lib/assets/javascripts/jack_up/file_uploader.coffee
+++ b/lib/assets/javascripts/jack_up/file_uploader.coffee
@@ -40,7 +40,7 @@ class @JackUp.FileUploader
     xhr.open 'POST', @path, true
 
     xhr.setRequestHeader 'Content-Type', file.type
-    xhr.setRequestHeader 'X-File-Name', file.name
+    xhr.setRequestHeader 'X-File-Name', unescape(encodeURIComponent(file.name)
     xhr.setRequestHeader 'X-CSRF-Token', $('meta[name=csrf-token]').attr('content')
 
     @trigger 'upload:start', file: file


### PR DESCRIPTION
When I tried to use jack_up to upload files with names, that are not english I got an error in FF

```
Cannot convert string to ByteString because the character at index 0 has value 1087 which is greater than 255
```

And in chrome I got

```
Uncaught SyntaxError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': 'привет!.jpg' is not a valid HTTP header field value. 
```

This is a small fix, that works for me.
