### PR TITLE
Don't force dropzone to be direct child of a form

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ jackUp.on "upload:success", (e, options) ->
   assetIdsElement = $("<input type='hidden' name='post[asset_ids][]'>").val(assetId)
   # append it to the form so saving the form associates the created post
   # with the uploaded assets
-  $(".file-drop").parent("form").append(assetIdsElement)
+  $(".file-drop").closest("form").append(assetIdsElement)
 ```
 
 ## License


### PR DESCRIPTION
Using `parent` here silently fails if a form is not a direct parent of a `.file-drop` element.
Using `closest` will traverse up to the first matching selector and so will find wrapping form.
